### PR TITLE
revert Chart constructor to Chart.js 1.x syntax

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -5,6 +5,6 @@ jQuery(document).ready(function($) {
 
   makeAjaxRequest(URL, function(json) {
     var data = generateDataSet(getHours(json), getFahrenheits(json));
-    var tempChart = new Chart.Line(ctx, {data: data, options: { bezierCurve: true}});
+    var tempChart = new Chart(ctx).Line(data, { bezierCurve: true });
   });
 });


### PR DESCRIPTION
Closes: https://github.com/learn-co-curriculum/js-weather-api-ajax/issues/14 and https://github.com/learn-co-students/js-weather-api-ajax-v-000/issues/94